### PR TITLE
fix: Resolve 404 error for vite.svg

### DIFF
--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-zap"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>


### PR DESCRIPTION
The application was failing to load because of a 404 error for the /vite.svg icon file. This change adds a placeholder vite.svg file to the public directory to resolve this issue.